### PR TITLE
Checkers Code Review + Linter fixes for them

### DIFF
--- a/src/games/checkers/checker.ts
+++ b/src/games/checkers/checker.ts
@@ -8,9 +8,7 @@ import { ICheckerState } from "./state-interfaces";
 
 // <<-- Creer-Merge: imports -->>
 // any additional imports you want can be added here safely between Creer runs
-
 import { ease } from "src/utils";
-import { RendererResource } from "src/viseur/renderer";
 import { Player } from "./player";
 // <<-- /Creer-Merge: imports -->>
 
@@ -67,10 +65,8 @@ export class Checker extends GameObject {
         // You can initialize your new Checker here.
         this.container.setParent(this.game.piecesContainer);
         this.owner = this.game.gameObjects[state.owner.id] as Player;
-        this.checker = (this.game.resources[`checker`] as RendererResource)
-            .newSprite(this.container);
-        this.king = (this.game.resources[`king`] as RendererResource)
-            .newSprite(this.container);
+        this.checker = this.game.resources.checker.newSprite(this.container);
+        this.king = this.game.resources.king.newSprite(this.container);
 
         this.king.visible = false;
         this.recolor();
@@ -111,8 +107,8 @@ export class Checker extends GameObject {
         };
 
         this.container.position.set(
-            ease(currentPosition.x, nextPosition.x, dt, "cubicInOut"),
-            ease(currentPosition.y, nextPosition.y, dt, "cubicInOut"),
+            ease(currentPosition.x, nextPosition.x, dt),
+            ease(currentPosition.y, nextPosition.y, dt),
         );
 
         // <<-- /Creer-Merge: render -->>

--- a/src/games/checkers/game.ts
+++ b/src/games/checkers/game.ts
@@ -43,8 +43,8 @@ export class Game extends BaseGame {
     /** The default player colors for this game, there must be one for each player */
     public readonly defaultPlayerColors: [Color, Color] = [
         // <<-- Creer-Merge: default-player-colors -->>
-        this.defaultPlayerColors[0], // Player 0
-        this.defaultPlayerColors[1], // Player 1
+        Color("#c92b10"), // Player 0 = red(ish)
+        Color("#3a3a3a"), // Player 1 = black (well dark gray)
         // <<-- /Creer-Merge: default-player-colors -->>
     ];
 

--- a/src/games/checkers/game.ts
+++ b/src/games/checkers/game.ts
@@ -97,8 +97,8 @@ export class Game extends BaseGame {
     protected getSize(state: IGameState): IRendererSize {
         return {
             // <<-- Creer-Merge: get-size -->>
-            width: 10, // Change these. Probably read in the map's width
-            height: 10, // and height from the initial state here.
+            width: state.boardWidth + this.borderLength * 2,
+            height: state.boardHeight + this.borderLength * 2,
             // <<-- /Creer-Merge: get-size -->>
         };
     }

--- a/src/games/checkers/game.ts
+++ b/src/games/checkers/game.ts
@@ -10,9 +10,7 @@ import { GameSettings } from "./settings";
 import { IGameState } from "./state-interfaces";
 
 // <<-- Creer-Merge: imports -->>
-// any additional imports you want can be added here safely between Creer runs
-import { RendererResource } from "src/viseur/renderer";
-
+// any additional imports you want can be added here safely between Creer runsW
 // <<-- /Creer-Merge: imports -->>
 
 /**
@@ -149,16 +147,16 @@ export class Game extends BaseGame {
         for (let x = 0; x < 8; x++) {
             this.tileSprites[x] = [];
             for (let y = 0; y < 8; y++) {
-                const color = (x + y) % 2
-                    ? "White"
-                    : "Black";
+                const resource = (x + y) % 2
+                    ? this.resources.tileWhite
+                    : this.resources.tileBlack;
 
-                this.tileSprites[x][y] = (this.resources[`tile${color}`] as RendererResource).newSprite(tileContainer, {
+                this.tileSprites[x][y] = resource.newSprite(tileContainer, {
                     tint: this.randomColor,
                     position: {
                         x,
                         y,
-                    }, /**/
+                    },
                 });
             }
         }

--- a/src/viseur/gui/info-pane/tabs/file-tab/file-tab.ts
+++ b/src/viseur/gui/info-pane/tabs/file-tab/file-tab.ts
@@ -296,9 +296,9 @@ export class FileTab extends Tab {
 
         viseur.events.connectionClosed.once((data) => {
             if (data.timedOut) {
-                this.log(`You timed out and were forcibly disconnected.`);
+                this.log("You timed out and were forcibly disconnected.");
             }
-            this.log(`Connection closed.`);
+            this.log("Connection closed.");
         });
 
         const type = this.connectTypeInput.value;

--- a/src/viseur/viseur.ts
+++ b/src/viseur/viseur.ts
@@ -435,7 +435,7 @@ export class Viseur {
         }
 
         if (this.game) {
-            throw new Error(`Viseur game already initialized`);
+            throw new Error("Viseur game already initialized");
         }
 
         if (!this.joueur) {

--- a/tslint.json
+++ b/tslint.json
@@ -44,7 +44,14 @@
             "requireParamType": false,
             "matchDescription": ".+"
         }],
-        "valid-typeof": true
+        "valid-typeof": true,
+        "no-string-literal": true,
+        "quotemark": [
+            true,
+            "double",
+            "avoid-escape",
+            "avoid-template"
+        ]
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
I did a code review on Checkers for you @MatthewQualls 

Overall it was good, but there were some potential problems:

So you had lines like these:

```ts
this.checker = (this.game.resources[`checker`] as RendererResource)
               .newSprite(this.container);
```

the correct way to code this is:

```ts
this.checker = this.game.resources.checker.newSprite(this.container);
```

Doing this has a few advantages:
1. shorter code
2. No unnecessary cast needed
3. typescript can perform type checking on the `checker` property and knows what methods it can do
4. Don't have to handle index not found errors because typescript knows what properties are present in the resources

In addition I've added a feature to `ease()` so that if you don't specify the easing type it defaults to cubic-in-out now, because we use that so much, so you can rewrite this:
```ts
ease(currentPosition.x, nextPosition.x, dt, "cubicInOut")
```

to this:

```ts
ease(currentPosition.x, nextPosition.x, dt)
```

Otherwise it all looks good. I just wanted to point out where you can improve your code and throw more of the workload on TypeScript instead of you the developer.