### PR TITLE
Fix spectating on visualizer

### DIFF
--- a/src/viseur/viseur.ts
+++ b/src/viseur/viseur.ts
@@ -170,7 +170,7 @@ export class Viseur {
     public spectate(server: string, port: number, gameName: string, session: string): void {
         this.gui.modalMessage("Spectating game...");
 
-        this.createJoueur({server, port, gameName, session});
+        this.createJoueur({server, port, gameName, session, spectating: true});
     }
 
     /**


### PR DESCRIPTION
was not properly adding specatating: true to the settings object when creating a spectator, which was causing it to make the client be added as a human player instead of spectating