### PR TITLE
Add tuple player progress bars option

### DIFF
--- a/_creer/src/games/${hyphenate(game_name)}/pane.ts
+++ b/_creer/src/games/${hyphenate(game_name)}/pane.ts
@@ -29,14 +29,17 @@ ${merge("        // ", "constructor", "        // constructor your pane here", h
 ${merge("    // ", "public-functions", "    // If you want to add more public functions, do so here", help=False)}
 
     /**
-     * Gets the stats for the players score bars
-     * @param state the current(most) state of the game to update this pane for
-     * @returns an array of numbers, where each index is the player at that
-     *          index. Sum does not matter, it will resize dynamically.
-     *          If You want to display no score, return undefined
-     *          or an empty array.
+     * Gets the stats for the players score bars.
+     *
+     * @param state - The current(most) state of the game to update this pane for.
+     * @returns An array of numbers, where each index is the player at that
+     * index. Sum does not matter, it will resize dynamically. If You want
+     * to display no score, return undefined.
+     * An array of numbers is treated as a full bar display.
+     * An array of number tuples is treated as individual bars alternatively
+     * left and right aligned scaling from the first to the max second value.
      */
-    protected getPlayersScores(state: Immutable<IGameState>): number[] | undefined {
+    protected getPlayersScores(state: Immutable<IGameState>): Array<[number, number]> | number[] | undefined {
         super.getPlayersScores(state);
 
 ${merge("        // ", "get-player-scores", "        return undefined; // change to return the states scores for each player", help=False)}

--- a/src/games/anarchy/pane.ts
+++ b/src/games/anarchy/pane.ts
@@ -37,14 +37,17 @@ export class Pane extends BasePane<IGameState, IPlayerState> {
     // <<-- /Creer-Merge: public-functions -->>
 
     /**
-     * Gets the stats for the players score bars
-     * @param state the current(most) state of the game to update this pane for
-     * @returns an array of numbers, where each index is the player at that
-     *          index. Sum does not matter, it will resize dynamically.
-     *          If You want to display no score, return undefined
-     *          or an empty array.
+     * Gets the stats for the players score bars.
+     *
+     * @param state - The current(most) state of the game to update this pane for.
+     * @returns An array of numbers, where each index is the player at that
+     * index. Sum does not matter, it will resize dynamically. If You want
+     * to display no score, return undefined.
+     * An array of numbers is treated as a full bar display.
+     * An array of number tuples is treated as individual bars alternatively
+     * left and right aligned scaling from the first to the max second value.
      */
-    protected getPlayersScores(state: Immutable<IGameState>): number[] | undefined {
+    protected getPlayersScores(state: Immutable<IGameState>): Array<[number, number]> | number[] | undefined {
         super.getPlayersScores(state);
 
         // <<-- Creer-Merge: get-player-scores -->>

--- a/src/games/catastrophe/pane.ts
+++ b/src/games/catastrophe/pane.ts
@@ -37,14 +37,17 @@ export class Pane extends BasePane<IGameState, IPlayerState> {
     // <<-- /Creer-Merge: public-functions -->>
 
     /**
-     * Gets the stats for the players score bars
-     * @param state the current(most) state of the game to update this pane for
-     * @returns an array of numbers, where each index is the player at that
-     *          index. Sum does not matter, it will resize dynamically.
-     *          If You want to display no score, return undefined
-     *          or an empty array.
+     * Gets the stats for the players score bars.
+     *
+     * @param state - The current(most) state of the game to update this pane for.
+     * @returns An array of numbers, where each index is the player at that
+     * index. Sum does not matter, it will resize dynamically. If You want
+     * to display no score, return undefined.
+     * An array of numbers is treated as a full bar display.
+     * An array of number tuples is treated as individual bars alternatively
+     * left and right aligned scaling from the first to the max second value.
      */
-    protected getPlayersScores(state: Immutable<IGameState>): number[] | undefined {
+    protected getPlayersScores(state: Immutable<IGameState>): Array<[number, number]> | number[] | undefined {
         super.getPlayersScores(state);
 
         // <<-- Creer-Merge: get-player-scores -->>

--- a/src/games/checkers/pane.ts
+++ b/src/games/checkers/pane.ts
@@ -37,14 +37,17 @@ export class Pane extends BasePane<IGameState, IPlayerState> {
     // <<-- /Creer-Merge: public-functions -->>
 
     /**
-     * Gets the stats for the players score bars
-     * @param state the current(most) state of the game to update this pane for
-     * @returns an array of numbers, where each index is the player at that
-     *          index. Sum does not matter, it will resize dynamically.
-     *          If You want to display no score, return undefined
-     *          or an empty array.
+     * Gets the stats for the players score bars.
+     *
+     * @param state - The current(most) state of the game to update this pane for.
+     * @returns An array of numbers, where each index is the player at that
+     * index. Sum does not matter, it will resize dynamically. If You want
+     * to display no score, return undefined.
+     * An array of numbers is treated as a full bar display.
+     * An array of number tuples is treated as individual bars alternatively
+     * left and right aligned scaling from the first to the max second value.
      */
-    protected getPlayersScores(state: Immutable<IGameState>): number[] | undefined {
+    protected getPlayersScores(state: Immutable<IGameState>): Array<[number, number]> | number[] | undefined {
         super.getPlayersScores(state);
 
         // <<-- Creer-Merge: get-player-scores -->>

--- a/src/games/chess/pane.ts
+++ b/src/games/chess/pane.ts
@@ -37,14 +37,17 @@ export class Pane extends BasePane<IGameState, IPlayerState> {
     // <<-- /Creer-Merge: public-functions -->>
 
     /**
-     * Gets the stats for the players score bars
-     * @param state the current(most) state of the game to update this pane for
-     * @returns an array of numbers, where each index is the player at that
-     *          index. Sum does not matter, it will resize dynamically.
-     *          If You want to display no score, return undefined
-     *          or an empty array.
+     * Gets the stats for the players score bars.
+     *
+     * @param state - The current(most) state of the game to update this pane for.
+     * @returns An array of numbers, where each index is the player at that
+     * index. Sum does not matter, it will resize dynamically. If You want
+     * to display no score, return undefined.
+     * An array of numbers is treated as a full bar display.
+     * An array of number tuples is treated as individual bars alternatively
+     * left and right aligned scaling from the first to the max second value.
      */
-    protected getPlayersScores(state: Immutable<IGameState>): number[] | undefined {
+    protected getPlayersScores(state: Immutable<IGameState>): Array<[number, number]> | number[] | undefined {
         super.getPlayersScores(state);
 
         // <<-- Creer-Merge: get-player-scores -->>

--- a/src/games/pirates/pane.ts
+++ b/src/games/pirates/pane.ts
@@ -37,14 +37,17 @@ export class Pane extends BasePane<IGameState, IPlayerState> {
     // <<-- /Creer-Merge: public-functions -->>
 
     /**
-     * Gets the stats for the players score bars
-     * @param state the current(most) state of the game to update this pane for
-     * @returns an array of numbers, where each index is the player at that
-     *          index. Sum does not matter, it will resize dynamically.
-     *          If You want to display no score, return undefined
-     *          or an empty array.
+     * Gets the stats for the players score bars.
+     *
+     * @param state - The current(most) state of the game to update this pane for.
+     * @returns An array of numbers, where each index is the player at that
+     * index. Sum does not matter, it will resize dynamically. If You want
+     * to display no score, return undefined.
+     * An array of numbers is treated as a full bar display.
+     * An array of number tuples is treated as individual bars alternatively
+     * left and right aligned scaling from the first to the max second value.
      */
-    protected getPlayersScores(state: Immutable<IGameState>): number[] | undefined {
+    protected getPlayersScores(state: Immutable<IGameState>): Array<[number, number]> | number[] | undefined {
         super.getPlayersScores(state);
 
         // <<-- Creer-Merge: get-player-scores -->>

--- a/src/games/saloon/pane.ts
+++ b/src/games/saloon/pane.ts
@@ -37,14 +37,17 @@ export class Pane extends BasePane<IGameState, IPlayerState> {
     // <<-- /Creer-Merge: public-functions -->>
 
     /**
-     * Gets the stats for the players score bars
-     * @param state the current(most) state of the game to update this pane for
-     * @returns an array of numbers, where each index is the player at that
-     *          index. Sum does not matter, it will resize dynamically.
-     *          If You want to display no score, return undefined
-     *          or an empty array.
+     * Gets the stats for the players score bars.
+     *
+     * @param state - The current(most) state of the game to update this pane for.
+     * @returns An array of numbers, where each index is the player at that
+     * index. Sum does not matter, it will resize dynamically. If You want
+     * to display no score, return undefined.
+     * An array of numbers is treated as a full bar display.
+     * An array of number tuples is treated as individual bars alternatively
+     * left and right aligned scaling from the first to the max second value.
      */
-    protected getPlayersScores(state: Immutable<IGameState>): number[] | undefined {
+    protected getPlayersScores(state: Immutable<IGameState>): Array<[number, number]> | number[] | undefined {
         super.getPlayersScores(state);
 
         // <<-- Creer-Merge: get-player-scores -->>

--- a/src/games/spiders/pane.ts
+++ b/src/games/spiders/pane.ts
@@ -36,14 +36,17 @@ export class Pane extends BasePane<IGameState, IPlayerState> {
     // <<-- /Creer-Merge: public-functions -->>
 
     /**
-     * Gets the stats for the players score bars
-     * @param state the current(most) state of the game to update this pane for
-     * @returns an array of numbers, where each index is the player at that
-     *          index. Sum does not matter, it will resize dynamically.
-     *          If You want to display no score, return undefined
-     *          or an empty array.
+     * Gets the stats for the players score bars.
+     *
+     * @param state - The current(most) state of the game to update this pane for.
+     * @returns An array of numbers, where each index is the player at that
+     * index. Sum does not matter, it will resize dynamically. If You want
+     * to display no score, return undefined.
+     * An array of numbers is treated as a full bar display.
+     * An array of number tuples is treated as individual bars alternatively
+     * left and right aligned scaling from the first to the max second value.
      */
-    protected getPlayersScores(state: Immutable<IGameState>): number[] | undefined {
+    protected getPlayersScores(state: Immutable<IGameState>): Array<[number, number]> | number[] | undefined {
         super.getPlayersScores(state);
 
         // <<-- Creer-Merge: get-player-scores -->>

--- a/src/games/stumped/pane.ts
+++ b/src/games/stumped/pane.ts
@@ -37,14 +37,17 @@ export class Pane extends BasePane<IGameState, IPlayerState> {
     // <<-- /Creer-Merge: public-functions -->>
 
     /**
-     * Gets the stats for the players score bars
-     * @param state the current(most) state of the game to update this pane for
-     * @returns an array of numbers, where each index is the player at that
-     *          index. Sum does not matter, it will resize dynamically.
-     *          If You want to display no score, return undefined
-     *          or an empty array.
+     * Gets the stats for the players score bars.
+     *
+     * @param state - The current(most) state of the game to update this pane for.
+     * @returns An array of numbers, where each index is the player at that
+     * index. Sum does not matter, it will resize dynamically. If You want
+     * to display no score, return undefined.
+     * An array of numbers is treated as a full bar display.
+     * An array of number tuples is treated as individual bars alternatively
+     * left and right aligned scaling from the first to the max second value.
      */
-    protected getPlayersScores(state: Immutable<IGameState>): number[] | undefined {
+    protected getPlayersScores(state: Immutable<IGameState>): Array<[number, number]> | number[] | undefined {
         super.getPlayersScores(state);
 
         // <<-- Creer-Merge: get-player-scores -->>


### PR DESCRIPTION
This adds an option for tuple based progress bar rendering for players:
![image](https://user-images.githubusercontent.com/1050503/47946271-8970b500-ded7-11e8-9a66-75b8568df7b4.png)
_(67/100 vs 71/100)_

Before there were two options in each game's `pane.ts Pane::getPlayersScores` :

- `undefined` - No player progress bars are displayed
- `number[]` - Each player's bar is the percentage of their number divided by the sum of all numbers. Both are then displayed "dueling" moving back and forth as the numbers change.

This adds a third return type:

- `Array<[number, number]>` - This is an array of tuples. First first number is the numerator, and the bottom the denominator. Then each player gets 1/n of the bar, where n is the number of players in a game (so 1/2 = 50% for a two player game). We then display their progress bar as the percent of the numerator/denominator, and alternatingly align them to the left or right. This means each progress bar can increase/decrease with no respect to the other player. This mode is ideal for games where each player needs to reach some absolute score to win, not an arbitrary relative score.

All games updated to support this mode, though none currently use it.