### PR TITLE
Fix random pauses issue#48

### DIFF
--- a/src/viseur/time-manager.ts
+++ b/src/viseur/time-manager.ts
@@ -131,7 +131,7 @@ export class TimeManager {
             const current = this.getCurrentTime();
             if (Math.abs(value - current.index - current.dt) > 0.10) {
                 // the change in time was too great, they probably clicked far away
-                this.pause(index, dt);
+                this.setTime(index, dt);
             }
         });
 


### PR DESCRIPTION
This changes the behavior of the visualizer so that when the user clicks
somehwere far away on the progress bar, it will no longer pause the
visualizer.  However the user can still manually pause playback by using
the pause button.
This fixes the random pauses because the visualizer interprets big
changes in the position of the slider as a mouse click, when sometimes
it will move far enough on its own without user interaction.